### PR TITLE
feat: change clock-delay api to Hz

### DIFF
--- a/src/cretro.c
+++ b/src/cretro.c
@@ -11,18 +11,18 @@
 
 int main(int argc, char** argv) {
 	if (argc != 3) {
-		fprintf(stderr, "Usage: ./cretro <DELAY> <ROM>\n");
+		fprintf(stderr, "Usage: ./cretro <CPU-FREQUENCY-IN-HZ> <ROM>\n");
         return EXIT_FAILURE;
 	}
 	
 	machine_init();
 
-    long inputDelay = strtol(argv[1], NULL, 10);
-    if (inputDelay > UINT16_MAX) {
-        fprintf(stderr, "Provided delay %ld is higher than allowed delay %d\n", inputDelay, UINT16_MAX);
+    long inputHertz = strtol(argv[1], NULL, 10);
+    if (inputHertz > 1000000L) {
+        fprintf(stderr, "Provided frequency %ld Hz is higher than allowed frequency %ld Hz\n", inputHertz, 1000000L);
         return EXIT_FAILURE;
     }
-	const uint16_t DELAY = (uint16_t) inputDelay;
+	const uint32_t USECOND_DELAY = (uint32_t) (1000000L / inputHertz);
 	const char* ROM_FILE_NAME = argv[2];
 
 	rom_load(ROM_FILE_NAME);
@@ -48,8 +48,8 @@ int main(int argc, char** argv) {
 
 		struct timeval clock_now;
 	    gettimeofday(&clock_now, NULL);
-		long dt = timediff_ms(&clock_now, &cpu_clock_prev);
-		if (dt > DELAY) {
+		long dt = timediff_us(&clock_now, &cpu_clock_prev);
+		if (dt > USECOND_DELAY) {
 			cpu_step();
 			lcd_step(m.video, videoPitch);
 			cpu_clock_prev = clock_now;

--- a/src/timer.c
+++ b/src/timer.c
@@ -2,9 +2,8 @@
 
 #define TIMER_DELAY (1000 / 60)
 
-long timediff_ms(const struct timeval *end, const struct timeval *start) {
-    long diff = (end->tv_sec - start->tv_sec) * 1000L +
-		(end->tv_usec - start->tv_usec) / 1000L;
+long timediff_us(const struct timeval *end, const struct timeval *start) {
+    long diff = (end->tv_sec - start->tv_sec) * 1000000L + (end->tv_usec - start->tv_usec);
     return diff;
 }
   

--- a/src/timer.h
+++ b/src/timer.h
@@ -12,6 +12,6 @@
 int nanosleep(const struct timespec *req, struct timespec *rem);
 int msleep(long msec);
 _Noreturn void *timer_update_callback(void* unused);
-__attribute__((pure)) long timediff_ms(const struct timeval *end, const struct timeval *start);
+__attribute__((pure)) long timediff_us(const struct timeval *end, const struct timeval *start);
 
 #endif


### PR DESCRIPTION
Use Hz to define the CPU clock speed instead of
providing the absolute millisecond delay