### PR TITLE
feat: targets for installing and uninstalling from ~/.local/bin/cretro

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ remove: clean
 .PHONY: install
 install: $(BINDIR)/$(TARGET)
 	@sudo cp $(BINDIR)/$(TARGET) $(INSTALL_PATH)
+	@echo "Installed to "$(INSTALL_PATH)
 
 .PHONY: uninstall
 uninstall:

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ SRCDIR	= src
 OBJDIR	= obj
 BINDIR	= .
 
-INSTALL_PATH = /usr/bin/$(TARGET)
+INSTALL_PATH = ~/.local/bin/$(TARGET)
 
 SOURCES		:= $(wildcard $(SRCDIR)/*.c)
 INCLUDES	:= $(wildcard $(SRCDIR)/*.h)
@@ -52,10 +52,10 @@ remove: clean
 
 .PHONY: install
 install: $(BINDIR)/$(TARGET)
-	@sudo cp $(BINDIR)/$(TARGET) $(INSTALL_PATH)
+	@cp $(BINDIR)/$(TARGET) $(INSTALL_PATH)
 	@echo "Installed to "$(INSTALL_PATH)
 
 .PHONY: uninstall
 uninstall:
-	@if [[ -f $(INSTALL_PATH) ]]; then sudo rm $(INSTALL_PATH); echo "Removed binary "$(INSTALL_PATH)"!"; else echo "Nothing to uninstall!"; fi
+	@if [[ -f $(INSTALL_PATH) ]]; then rm $(INSTALL_PATH); echo "Removed binary "$(INSTALL_PATH)"!"; else echo "Nothing to uninstall!"; fi
 

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ SRCDIR	= src
 OBJDIR	= obj
 BINDIR	= .
 
+INSTALL_PATH = /usr/bin/$(TARGET)
+
 SOURCES		:= $(wildcard $(SRCDIR)/*.c)
 INCLUDES	:= $(wildcard $(SRCDIR)/*.h)
 OBJECTS		:= $(SOURCES:$(SRCDIR)/%.c=$(OBJDIR)/%.o)
@@ -47,3 +49,12 @@ clean:
 remove: clean
 	@$(rm) $(BINDIR)/$(TARGET)
 	@echo "Executable removed!"
+
+.PHONY: install
+install: $(BINDIR)/$(TARGET)
+	@sudo cp $(BINDIR)/$(TARGET) $(INSTALL_PATH)
+
+.PHONY: uninstall
+uninstall:
+	@if [[ -f $(INSTALL_PATH) ]]; then sudo rm $(INSTALL_PATH); echo "Removed binary "$(INSTALL_PATH)"!"; else echo "Nothing to uninstall!"; fi
+


### PR DESCRIPTION
Enables you to execute 
```
make install
```
to install the resulting binary to `~/.local/bin/cretro`. The binary can be removed via 
```
make uninstall
```
