### PR TITLE
Introduce clang-format and clang-tidy

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -13,7 +13,7 @@ AllowAllArgumentsOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: Empty
 AllowShortCaseLabelsOnASingleLine: false
-AllowShortEnumsOnASingleLine: true
+AllowShortEnumsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: None
 AllowShortIfStatementsOnASingleLine: Never
 AllowShortLoopsOnASingleLine: false

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,113 @@
+Language: Cpp
+
+AlignArrayOfStructures: Left
+AlignConsecutiveAssignments: AcrossComments
+AlignConsecutiveBitFields: None
+AlignConsecutiveDeclarations: None
+AlignConsecutiveMacros: AcrossComments
+AlignEscapedNewlines: Right
+AlignOperands: Align
+AlignTrailingComments: true
+
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Empty
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortEnumsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+
+BitFieldColonSpacing: Both
+
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: false
+
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBraces: Attach
+BreakBeforeTernaryOperators: true
+BreakStringLiterals: true
+
+ColumnLimit: 111
+
+ContinuationIndentWidth: 4
+
+DeriveLineEnding: true
+DerivePointerAlignment: false
+
+DisableFormat: false
+
+IncludeBlocks: Merge
+
+IndentCaseBlocks: false
+IndentCaseLabels: true
+IndentExternBlock: Indent
+IndentGotoLabels: true
+IndentPPDirectives: BeforeHash
+IndentWidth: 4
+IndentWrappedFunctionNames: true
+
+KeepEmptyLinesAtTheStartOfBlocks: false
+
+InsertTrailingCommas: None
+
+MaxEmptyLinesToKeep: 1
+
+PPIndentWidth: 1
+
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PenaltyIndentedWhitespace: 0
+
+PointerAlignment: Right
+
+QualifierAlignment: Custom
+QualifierOrder: ['inline', 'static', 'restrict', 'type', 'const', 'volatile' ]
+
+ReflowComments: true
+
+SortIncludes: Never
+
+SpaceAfterCStyleCast: true
+SpaceAfterLogicalNot: false
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeParens: ControlStatementsExceptControlMacros
+SpacesInSquareBrackets: false
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInCStyleCastParentheses: false
+SpacesInConditionalStatement: false
+SpacesInParentheses: false
+SpaceBeforeSquareBrackets: false
+
+UseTab: Always
+TabWidth: 4
+
+UseCRLF: false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,13 @@
+Checks: '-*,readability-identifier-naming'
+CheckOptions:
+  - { key: readability-identifier-naming.VariableCase, value: lower_case }
+  - { key: readability-identifier-naming.FunctionCase, value: lower_case }
+  - { key: readability-identifier-naming.FunctionIgnoredRegexp, value: "OPC_.*" }
+  - { key: readability-identifier-naming.GlobalFunctionCase, value: lower_case }
+  - { key: readability-identifier-naming.GlobalFunctionIgnoredRegexp, value: "OPC_.*" }
+  - { key: readability-identifier-naming.ParameterCase, value: lower_case }
+  - { key: readability-identifier-naming.StructCase, value: lower_case }
+  - { key: readability-identifier-naming.EnumCase, value: lower_case }
+  - { key: readability-identifier-naming.TypedefCase, value: lower_case }
+  - { key: readability-identifier-naming.MacroDefinitionCase, value: UPPER_CASE }
+  - { key: readability-identifier-naming.MacroDefinitionCase, value: UPPER_CASE }

--- a/run-clang-format.sh
+++ b/run-clang-format.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+find src/ -iname *.h -o -iname *.c | xargs clang-format -i

--- a/run-clang-tidy.sh
+++ b/run-clang-tidy.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# Clean up before regenerating compilation files
+make clean
+
+# Check whether bear (https://github.com/rizsotto/Bear) is installed
+# This is required to generate compile_commands.json that clang-tidy requires
+if ! [ -x "$(command -v bear)" ]; then
+    echo "bear could not be found. Please install it."
+    exit
+fi
+
+bear -- make
+
+find src/ -iname *.h -o -iname *.c | xargs clang-tidy --fix --fix-errors --config-file=.clang-tidy

--- a/src/cli.c
+++ b/src/cli.c
@@ -19,124 +19,124 @@
  *** LOCAL VARIABLES                                ***
  ******************************************************/
 
-static const char* usage_str = "cretro [-d <0..4>] [-f <FREQUENCY_HZ>] <ROM>";
+static char const *usage_str = "cretro [-d <0..4>] [-f <FREQUENCY_HZ>] <ROM>";
 
 /******************************************************
  *** LOCAL METHODS                                  ***
  ******************************************************/
 
-static int safe_strtol(const char* str_to_conv, int* store_into) {
-    char* end;
-    const long strtol_in = strtol(str_to_conv, &end, 10);
+static int safe_strtol(char const *str_to_conv, int *store_into) {
+	char *end;
+	long const strtol_in = strtol(str_to_conv, &end, 10);
 
-    errno = 0;
+	errno = 0;
 
-    if (end == str_to_conv) {
-        LOG_FATAL("%s: not a decimal number", str_to_conv);
-    } else if ('\0' != *end) {
-        LOG_FATAL("%s: extra characters at end of input: %s", str_to_conv, end);
-    } else if ((LONG_MIN == strtol_in || LONG_MAX == strtol_in) && ERANGE == errno) {
-        LOG_FATAL("%s out of range of type long", str_to_conv);
-    } else if (strtol_in > INT_MAX) {
-        LOG_FATAL("%ld greater than INT_MAX", strtol_in);
-    } else if (strtol_in < INT_MIN) {
-        LOG_FATAL("%ld less than INT_MIN", strtol_in);
-    } else {
-        *store_into = (int)strtol_in;
-        return EXIT_SUCCESS;
-    }
+	if (end == str_to_conv) {
+		LOG_FATAL("%s: not a decimal number", str_to_conv);
+	} else if ('\0' != *end) {
+		LOG_FATAL("%s: extra characters at end of input: %s", str_to_conv, end);
+	} else if ((LONG_MIN == strtol_in || LONG_MAX == strtol_in) && ERANGE == errno) {
+		LOG_FATAL("%s out of range of type long", str_to_conv);
+	} else if (strtol_in > INT_MAX) {
+		LOG_FATAL("%ld greater than INT_MAX", strtol_in);
+	} else if (strtol_in < INT_MIN) {
+		LOG_FATAL("%ld less than INT_MIN", strtol_in);
+	} else {
+		*store_into = (int) strtol_in;
+		return EXIT_SUCCESS;
+	}
 
-    return EXIT_FAILURE;
+	return EXIT_FAILURE;
 }
 
-static void handle_arg_frequency(arg_conf* conf, long frequency) {
-    // calculate delay from hertz input
-    LOG_DEBUG("Frequency [Hz] input specified: %ld.", frequency);
+static void handle_arg_frequency(arg_conf *conf, long frequency) {
+	// calculate delay from hertz input
+	LOG_DEBUG("Frequency [Hz] input specified: %ld.", frequency);
 
-    if (frequency > MAX_HZ) {
-        LOG_ERROR("Provided frequency %ld is higher than allowed frequency %ld. Used Fallback: %ld", frequency, MAX_HZ, MAX_HZ);
-        frequency = MAX_HZ;
-    }
-    else if (frequency <= 0) {
-        LOG_ERROR("Provided frequency %ld is lower or equal to 0. Used Fallback: %ld", frequency, MAX_HZ);
-        frequency = MAX_HZ;
-    }
+	if (frequency > MAX_HZ) {
+		LOG_ERROR("Provided frequency %ld is higher than allowed frequency %ld. Used Fallback: %ld", frequency,
+				  MAX_HZ, MAX_HZ);
+		frequency = MAX_HZ;
+	} else if (frequency <= 0) {
+		LOG_ERROR("Provided frequency %ld is lower or equal to 0. Used Fallback: %ld", frequency, MAX_HZ);
+		frequency = MAX_HZ;
+	}
 
-    long delay = MAX_HZ / frequency;
-    if (delay > INT_MAX)
-        LOG_FATAL("Delay is out of bounds: %d > %d", delay, INT_MAX);
+	long delay = MAX_HZ / frequency;
+	if (delay > INT_MAX)
+		LOG_FATAL("Delay is out of bounds: %d > %d", delay, INT_MAX);
 
-    conf->us_delay = (int) (delay);
-    LOG_INFO("Delay set to %d us.", conf->us_delay);
+	conf->us_delay = (int) (delay);
+	LOG_INFO("Delay set to %d us.", conf->us_delay);
 }
 
 /******************************************************
  *** EXPOSED METHODS                                ***
  ******************************************************/
 
-arg_conf* cli_config_default(void) {
-    arg_conf* conf = malloc(sizeof(arg_conf));
+arg_conf *cli_config_default(void) {
+	arg_conf *conf = malloc(sizeof(arg_conf));
 
-    conf->debug = FATAL;
-    conf->us_delay = 0;
-    conf->rom_path = "";
+	conf->debug	   = FATAL;
+	conf->us_delay = 0;
+	conf->rom_path = "";
 
-    return conf;
+	return conf;
 }
 
 void cli_config_destroy(arg_conf *conf) {
-    free(conf);
+	free(conf);
 }
 
-int cli_config_handle(arg_conf* const conf, int argc, char **argv) {
-    int c;
+int cli_config_handle(arg_conf *const conf, int argc, char **argv) {
+	int c;
 
-    if (argc < 2) {
-        LOG_FATAL("No ROM path specified!");
-        fprintf(stderr, "%s\n", usage_str);
-        return EXIT_FAILURE;
-    }
+	if (argc < 2) {
+		LOG_FATAL("No ROM path specified!");
+		fprintf(stderr, "%s\n", usage_str);
+		return EXIT_FAILURE;
+	}
 
-    // parse all options first
-    int strtol_in;
-    while ((c = getopt(argc, argv, "d:f:")) != -1) {
-        switch (c) {
-            case 'd':
-                if (safe_strtol(optarg, &strtol_in))
-                    return EXIT_FAILURE;
+	// parse all options first
+	int strtol_in;
+	while ((c = getopt(argc, argv, "d:f:")) != -1) {
+		switch (c) {
+			case 'd':
+				if (safe_strtol(optarg, &strtol_in))
+					return EXIT_FAILURE;
 
-                conf->debug = strtol_in;
-                log_set_lvl(conf);
-                break;
-            case 'f':
-                if (safe_strtol(optarg, &strtol_in))
-                    return EXIT_FAILURE;
+				conf->debug = strtol_in;
+				log_set_lvl(conf);
+				break;
+			case 'f':
+				if (safe_strtol(optarg, &strtol_in))
+					return EXIT_FAILURE;
 
-                handle_arg_frequency(conf, strtol_in);
-                break;
-            default:
-                fprintf(stderr, "%s\n", usage_str);
-                return EXIT_FAILURE;
-        }
-    }
+				handle_arg_frequency(conf, strtol_in);
+				break;
+			default:
+				fprintf(stderr, "%s\n", usage_str);
+				return EXIT_FAILURE;
+		}
+	}
 
-    // parse the remaining options
+	// parse the remaining options
 
-    if (argc - optind > 1) {
-        LOG_FATAL("You provided too many arguments!");
-        fprintf(stderr, "%s\n", usage_str);
-        return EXIT_FAILURE;
-    }
+	if (argc - optind > 1) {
+		LOG_FATAL("You provided too many arguments!");
+		fprintf(stderr, "%s\n", usage_str);
+		return EXIT_FAILURE;
+	}
 
-    if (optind >= argc) {
-        LOG_FATAL("No ROM path specified!");
-        fprintf(stderr, "%s\n", usage_str);
-        return EXIT_FAILURE;
-    }
+	if (optind >= argc) {
+		LOG_FATAL("No ROM path specified!");
+		fprintf(stderr, "%s\n", usage_str);
+		return EXIT_FAILURE;
+	}
 
-    // path to rom is the only remaining argument
-    conf->rom_path = argv[optind++];
-    LOG_DEBUG("Path to ROM: %s", conf->rom_path);
+	// path to rom is the only remaining argument
+	conf->rom_path = argv[optind++];
+	LOG_DEBUG("Path to ROM: %s", conf->rom_path);
 
-    return EXIT_SUCCESS;
+	return EXIT_SUCCESS;
 }

--- a/src/cli.h
+++ b/src/cli.h
@@ -1,5 +1,5 @@
-#ifndef _CRETRO_SRC_CLI_H_
-#define _CRETRO_SRC_CLI_H_
+#ifndef CLI_H
+#define CLI_H
 
 #include <stdint.h>
 
@@ -15,4 +15,4 @@ void cli_config_destroy(arg_conf *conf);
 
 int cli_config_handle(arg_conf *const conf, int argc, char **argv);
 
-#endif /* _CRETRO_SRC_CLI_H_ */
+#endif /* CLI_H */

--- a/src/cli.h
+++ b/src/cli.h
@@ -4,15 +4,15 @@
 #include <stdint.h>
 
 typedef struct arg_conf {
-    int debug;
-    int us_delay;
-    const char* rom_path;
+	int debug;
+	int us_delay;
+	char const *rom_path;
 } arg_conf;
 
-arg_conf* cli_config_default(void);
+arg_conf *cli_config_default(void);
 
 void cli_config_destroy(arg_conf *conf);
 
-int cli_config_handle(arg_conf* const conf, int argc, char **argv);
+int cli_config_handle(arg_conf *const conf, int argc, char **argv);
 
 #endif /* _CRETRO_SRC_CLI_H_ */

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -19,16 +19,16 @@ typedef void (*op_function)(void);
 // Function is used for instruction array initialization, not recognized by compiler
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
-static void ILLEGAL_OPCODE(void) {
+static void illegal_opcode(void) {
 	LOG_ERROR("Unallowed OP Code!");
 }
 #pragma GCC diagnostic pop
 
-op_function instr_lookup[0xF + 1]		   = {[0 ... 0xF] = ILLEGAL_OPCODE};
-op_function zero_prefixed_lookup[0xE + 1]  = {[0 ... 0xE] = ILLEGAL_OPCODE};
-op_function eight_prefixed_lookup[0xE + 1] = {[0 ... 0xE] = ILLEGAL_OPCODE};
-op_function e_prefixed_lookup[0xE + 1]	   = {[0 ... 0xE] = ILLEGAL_OPCODE};
-op_function f_prefixed_lookup[0x65 + 1]	   = {[0 ... 0x65] = ILLEGAL_OPCODE};
+op_function instr_lookup[0xF + 1]		   = {[0 ... 0xF] = illegal_opcode};
+op_function zero_prefixed_lookup[0xE + 1]  = {[0 ... 0xE] = illegal_opcode};
+op_function eight_prefixed_lookup[0xE + 1] = {[0 ... 0xE] = illegal_opcode};
+op_function e_prefixed_lookup[0xE + 1]	   = {[0 ... 0xE] = illegal_opcode};
+op_function f_prefixed_lookup[0x65 + 1]	   = {[0 ... 0x65] = illegal_opcode};
 
 uint8_t fontset[FONTSET_SIZE] = {
 	0xF0, 0x90, 0x90, 0x90, 0xF0, // 0
@@ -67,7 +67,7 @@ machine_t m = {
 
 void rom_load(char const *filename) {
 	FILE *f;
-	long romSize;
+	long rom_size;
 
 	// Open ROM
 	LOG_INFO("Loading ROM %s", filename);
@@ -79,16 +79,16 @@ void rom_load(char const *filename) {
 
 	// Get the number of bytes
 	fseek(f, 0L, SEEK_END);
-	romSize = ftell(f);
+	rom_size = ftell(f);
 
-	LOG_DEBUG("Size of ROM: %ld", romSize);
+	LOG_DEBUG("Size of ROM: %ld", rom_size);
 
-	if (romSize < 0) {
+	if (rom_size < 0) {
 		LOG_FATAL("%s", strerror(errno));
 		fclose(f);
 		return;
-	} else if (((unsigned long) romSize) >= UINT16_MAX) {
-		LOG_FATAL("Size of rom %s (%ld) is larger than maximal allowed size %d", filename, romSize,
+	} else if (((unsigned long) rom_size) >= UINT16_MAX) {
+		LOG_FATAL("Size of rom %s (%ld) is larger than maximal allowed size %d", filename, rom_size,
 				  UINT16_MAX);
 		fclose(f);
 		return;
@@ -97,30 +97,30 @@ void rom_load(char const *filename) {
 	// reset pointer to beginning of file
 	fseek(f, 0L, SEEK_SET);
 
-	size_t bytesRead = fread(&m.memory[START_ADDRESS], sizeof(uint8_t), (size_t) romSize, f);
-	if (bytesRead != (size_t) romSize) {
+	size_t bytes_read = fread(&m.memory[START_ADDRESS], sizeof(uint8_t), (size_t) rom_size, f);
+	if (bytes_read != (size_t) rom_size) {
 		LOG_FATAL("An error occurred while reading bytes from rom");
 		fclose(f);
 		return;
 	}
 
-	LOG_DEBUG("Successfully read %ld B of ROM", romSize);
+	LOG_DEBUG("Successfully read %ld B of ROM", rom_size);
 	fclose(f);
 }
 
-static void ZERO_PREFIXED(void) {
+static void zero_prefixed(void) {
 	zero_prefixed_lookup[GET_N(m.opcode)]();
 }
 
-static void EIGHT_PREFIXED(void) {
+static void eight_prefixed(void) {
 	eight_prefixed_lookup[GET_N(m.opcode)]();
 }
 
-static void E_PREFIXED(void) {
+static void e_prefixed(void) {
 	e_prefixed_lookup[GET_N(m.opcode)]();
 }
 
-static void F_PREFIXED(void) {
+static void f_prefixed(void) {
 	f_prefixed_lookup[GET_KK(m.opcode)]();
 }
 
@@ -133,7 +133,7 @@ void machine_init(void) {
 	memcpy(&m.memory[FONTSET_START_ADDRESS], fontset, FONTSET_SIZE);
 
 	// Set up lookup table
-	instr_lookup[0x0] = ZERO_PREFIXED;
+	instr_lookup[0x0] = zero_prefixed;
 	instr_lookup[0x1] = OPC_1nnn;
 	instr_lookup[0x2] = OPC_2nnn;
 	instr_lookup[0x3] = OPC_3xkk;
@@ -141,14 +141,14 @@ void machine_init(void) {
 	instr_lookup[0x5] = OPC_5xy0;
 	instr_lookup[0x6] = OPC_6xkk;
 	instr_lookup[0x7] = OPC_7xkk;
-	instr_lookup[0x8] = EIGHT_PREFIXED;
+	instr_lookup[0x8] = eight_prefixed;
 	instr_lookup[0x9] = OPC_9xy0;
 	instr_lookup[0xA] = OPC_Annn;
 	instr_lookup[0xB] = OPC_Bnnn;
 	instr_lookup[0xC] = OPC_Cxkk;
 	instr_lookup[0xD] = OPC_Dxyn;
-	instr_lookup[0xE] = E_PREFIXED;
-	instr_lookup[0xF] = F_PREFIXED;
+	instr_lookup[0xE] = e_prefixed;
+	instr_lookup[0xF] = f_prefixed;
 
 	zero_prefixed_lookup[0x0] = OPC_00E0;
 	zero_prefixed_lookup[0xE] = OPC_00EE;
@@ -211,127 +211,127 @@ void OPC_2nnn(void) {
 }
 
 void OPC_3xkk(void) {
-	uint8_t Vx	 = GET_X(m.opcode);
+	uint8_t vx	 = GET_X(m.opcode);
 	uint8_t byte = GET_KK(m.opcode);
 
-	if (m.registers[Vx] == byte) {
+	if (m.registers[vx] == byte) {
 		m.PC += 2;
 	}
 }
 
 void OPC_4xkk(void) {
-	uint8_t Vx	 = GET_X(m.opcode);
+	uint8_t vx	 = GET_X(m.opcode);
 	uint8_t byte = GET_KK(m.opcode);
 
-	if (m.registers[Vx] != byte) {
+	if (m.registers[vx] != byte) {
 		m.PC += 2;
 	}
 }
 
 void OPC_5xy0(void) {
-	uint8_t Vx = GET_X(m.opcode);
-	uint8_t Vy = GET_Y(m.opcode);
+	uint8_t vx = GET_X(m.opcode);
+	uint8_t vy = GET_Y(m.opcode);
 
-	if (m.registers[Vx] == m.registers[Vy]) {
+	if (m.registers[vx] == m.registers[vy]) {
 		m.PC += 2;
 	}
 }
 
 void OPC_6xkk(void) {
-	uint8_t Vx	 = GET_X(m.opcode);
+	uint8_t vx	 = GET_X(m.opcode);
 	uint8_t byte = GET_KK(m.opcode);
 
-	m.registers[Vx] = byte;
+	m.registers[vx] = byte;
 }
 
 void OPC_7xkk(void) {
-	uint8_t Vx	 = GET_X(m.opcode);
+	uint8_t vx	 = GET_X(m.opcode);
 	uint8_t byte = GET_KK(m.opcode);
 
-	m.registers[Vx] += byte;
+	m.registers[vx] += byte;
 }
 
 void OPC_8xy0(void) {
-	uint8_t Vx = GET_X(m.opcode);
-	uint8_t Vy = GET_Y(m.opcode);
+	uint8_t vx = GET_X(m.opcode);
+	uint8_t vy = GET_Y(m.opcode);
 
-	m.registers[Vx] = m.registers[Vy];
+	m.registers[vx] = m.registers[vy];
 }
 
 void OPC_8xy1(void) {
-	uint8_t Vx = GET_X(m.opcode);
-	uint8_t Vy = GET_Y(m.opcode);
+	uint8_t vx = GET_X(m.opcode);
+	uint8_t vy = GET_Y(m.opcode);
 
-	m.registers[Vx] |= m.registers[Vy];
+	m.registers[vx] |= m.registers[vy];
 }
 
 void OPC_8xy2(void) {
-	uint8_t Vx = GET_X(m.opcode);
-	uint8_t Vy = GET_Y(m.opcode);
+	uint8_t vx = GET_X(m.opcode);
+	uint8_t vy = GET_Y(m.opcode);
 
-	m.registers[Vx] &= m.registers[Vy];
+	m.registers[vx] &= m.registers[vy];
 }
 
 void OPC_8xy3(void) {
-	uint8_t Vx = GET_X(m.opcode);
-	uint8_t Vy = GET_Y(m.opcode);
+	uint8_t vx = GET_X(m.opcode);
+	uint8_t vy = GET_Y(m.opcode);
 
-	m.registers[Vx] ^= m.registers[Vy];
+	m.registers[vx] ^= m.registers[vy];
 }
 
 void OPC_8xy4(void) {
-	uint8_t Vx = GET_X(m.opcode);
-	uint8_t Vy = GET_Y(m.opcode);
+	uint8_t vx = GET_X(m.opcode);
+	uint8_t vy = GET_Y(m.opcode);
 
-	uint16_t sum = m.registers[Vx] + m.registers[Vy];
+	uint16_t sum = m.registers[vx] + m.registers[vy];
 
 	m.registers[0xF] = sum > 255;
 
-	m.registers[Vx] = (uint8_t) (sum & 0xFF);
+	m.registers[vx] = (uint8_t) (sum & 0xFF);
 }
 
 void OPC_8xy5(void) {
-	uint8_t Vx = GET_X(m.opcode);
-	uint8_t Vy = GET_Y(m.opcode);
+	uint8_t vx = GET_X(m.opcode);
+	uint8_t vy = GET_Y(m.opcode);
 
-	m.registers[0xF] = m.registers[Vx] > m.registers[Vy];
+	m.registers[0xF] = m.registers[vx] > m.registers[vy];
 
-	m.registers[Vx] -= m.registers[Vy];
+	m.registers[vx] -= m.registers[vy];
 }
 
 void OPC_8xy6(void) {
-	uint8_t Vx = GET_X(m.opcode);
+	uint8_t vx = GET_X(m.opcode);
 
 	// Save LSB in VF
-	m.registers[0xF] = m.registers[Vx] & 0x1;
+	m.registers[0xF] = m.registers[vx] & 0x1;
 
-	m.registers[Vx] = m.registers[Vx] >> 1;
+	m.registers[vx] = m.registers[vx] >> 1;
 }
 
 void OPC_8xy7(void) {
-	uint8_t Vx = GET_X(m.opcode);
-	uint8_t Vy = GET_Y(m.opcode);
+	uint8_t vx = GET_X(m.opcode);
+	uint8_t vy = GET_Y(m.opcode);
 
-	m.registers[0xF] = m.registers[Vy] > m.registers[Vx];
+	m.registers[0xF] = m.registers[vy] > m.registers[vx];
 
-	m.registers[Vx] = m.registers[Vy] - m.registers[Vx];
+	m.registers[vx] = m.registers[vy] - m.registers[vx];
 }
 
 void OPC_8xyE(void) {
-	uint8_t Vx = GET_X(m.opcode);
+	uint8_t vx = GET_X(m.opcode);
 
 	// Save MSB in VF because if msb = 1 set VF to 1
 	// analogously with msb = 0
-	m.registers[0xF] = (m.registers[Vx] & 0b10000000) >> 7;
+	m.registers[0xF] = (m.registers[vx] & 0b10000000) >> 7;
 
-	m.registers[Vx] = m.registers[Vx] << 1;
+	m.registers[vx] = m.registers[vx] << 1;
 }
 
 void OPC_9xy0(void) {
-	uint8_t Vx = GET_X(m.opcode);
-	uint8_t Vy = GET_Y(m.opcode);
+	uint8_t vx = GET_X(m.opcode);
+	uint8_t vy = GET_Y(m.opcode);
 
-	if (m.registers[Vx] != m.registers[Vy]) {
+	if (m.registers[vx] != m.registers[vy]) {
 		m.PC += 2;
 	}
 }
@@ -350,30 +350,30 @@ void OPC_Bnnn(void) {
 }
 
 void OPC_Cxkk(void) {
-	uint8_t Vx	   = GET_X(m.opcode);
+	uint8_t vx	   = GET_X(m.opcode);
 	uint8_t byte   = GET_KK(m.opcode);
 	uint8_t random = (uint8_t) (rand() & byte);
 
-	m.registers[Vx] = random & byte;
+	m.registers[vx] = random & byte;
 }
 
 void OPC_Dxyn(void) {
-	uint_fast8_t Vx		= (m.opcode & 0x0F00u) >> 8u;
-	uint_fast8_t Vy		= (m.opcode & 0x00F0u) >> 4u;
+	uint_fast8_t vx		= (m.opcode & 0x0F00u) >> 8u;
+	uint_fast8_t vy		= (m.opcode & 0x00F0u) >> 4u;
 	uint_fast8_t height = m.opcode & 0x000Fu;
 
 	// Wrap if going beyond screen boundaries
-	uint_fast8_t vxValue = m.registers[Vx] % VIDEO_WIDTH;
-	uint_fast8_t vyValue = m.registers[Vy] % VIDEO_HEIGHT;
+	uint_fast8_t vx_value = m.registers[vx] % VIDEO_WIDTH;
+	uint_fast8_t vy_value = m.registers[vy] % VIDEO_HEIGHT;
 
 	m.registers[0xF] = 0;
 
 	for (uint_fast8_t row = 0; row < height; ++row) {
-		uint_fast8_t spritePixel = m.memory[m.index + row];
+		uint_fast8_t sprite_pixel = m.memory[m.index + row];
 
 		for (uint_fast8_t col = 0; col < 8; ++col) {
-			uint_fast8_t bit = spritePixel & (0b10000000 >> col);
-			uint32_t *pixel	 = &m.video[(vyValue + row) * VIDEO_WIDTH + (vxValue + col)];
+			uint_fast8_t bit = sprite_pixel & (0b10000000 >> col);
+			uint32_t *pixel	 = &m.video[(vy_value + row) * VIDEO_WIDTH + (vx_value + col)];
 
 			// Sprite pixel is set
 			if (bit) {
@@ -388,8 +388,8 @@ void OPC_Dxyn(void) {
 }
 
 void OPC_Ex9E(void) {
-	uint8_t Vx	= GET_X(m.opcode);
-	uint8_t key = m.registers[Vx];
+	uint8_t vx	= GET_X(m.opcode);
+	uint8_t key = m.registers[vx];
 
 	if (m.keys[key]) {
 		m.PC += 2;
@@ -397,8 +397,8 @@ void OPC_Ex9E(void) {
 }
 
 void OPC_ExA1(void) {
-	uint8_t Vx	= GET_X(m.opcode);
-	uint8_t key = m.registers[Vx];
+	uint8_t vx	= GET_X(m.opcode);
+	uint8_t key = m.registers[vx];
 
 	if (!m.keys[key]) {
 		m.PC += 2;
@@ -406,16 +406,16 @@ void OPC_ExA1(void) {
 }
 
 void OPC_Fx07(void) {
-	uint8_t Vx		= GET_X(m.opcode);
-	m.registers[Vx] = m.delay_timer;
+	uint8_t vx		= GET_X(m.opcode);
+	m.registers[vx] = m.delay_timer;
 }
 
 void OPC_Fx0A(void) {
-	uint8_t Vx = GET_X(m.opcode);
+	uint8_t vx = GET_X(m.opcode);
 
 	for (int i = 0; i < 16; ++i) {
 		if (m.keys[i]) {
-			m.registers[Vx] = (uint8_t) i;
+			m.registers[vx] = (uint8_t) i;
 			return;
 		}
 	}
@@ -424,33 +424,33 @@ void OPC_Fx0A(void) {
 }
 
 void OPC_Fx15(void) {
-	uint8_t Vx = GET_X(m.opcode);
+	uint8_t vx = GET_X(m.opcode);
 
-	m.delay_timer = m.registers[Vx];
+	m.delay_timer = m.registers[vx];
 }
 
 void OPC_Fx18(void) {
-	uint8_t Vx = GET_X(m.opcode);
+	uint8_t vx = GET_X(m.opcode);
 
-	m.sound_timer = m.registers[Vx];
+	m.sound_timer = m.registers[vx];
 }
 
 void OPC_Fx1E(void) {
-	uint8_t Vx = GET_X(m.opcode);
+	uint8_t vx = GET_X(m.opcode);
 
-	m.index += m.registers[Vx];
+	m.index += m.registers[vx];
 }
 
 void OPC_Fx29(void) {
-	uint8_t Vx	  = GET_X(m.opcode);
-	uint8_t value = m.registers[Vx];
+	uint8_t vx	  = GET_X(m.opcode);
+	uint8_t value = m.registers[vx];
 
 	m.index = FONTSET_START_ADDRESS + (5 * value); // 5 = font char width
 }
 
 void OPC_Fx33(void) {
-	uint8_t Vx	  = GET_X(m.opcode);
-	uint8_t value = m.registers[Vx];
+	uint8_t vx	  = GET_X(m.opcode);
+	uint8_t value = m.registers[vx];
 
 	// 1s
 	m.memory[m.index + 2] = value % 10;
@@ -465,13 +465,13 @@ void OPC_Fx33(void) {
 }
 
 void OPC_Fx55(void) {
-	uint8_t Vx = GET_X(m.opcode);
+	uint8_t vx = GET_X(m.opcode);
 
-	memcpy(&m.memory[m.index], m.registers, Vx + 1);
+	memcpy(&m.memory[m.index], m.registers, vx + 1);
 }
 
 void OPC_Fx65(void) {
-	uint8_t Vx = GET_X(m.opcode);
+	uint8_t vx = GET_X(m.opcode);
 
-	memcpy(m.registers, &m.memory[m.index], Vx + 1);
+	memcpy(m.registers, &m.memory[m.index], vx + 1);
 }

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -4,14 +4,14 @@
 #include "sound.h"
 #include "logging.h"
 
-#define FONTSET_SIZE 80
+#define FONTSET_SIZE		  80
 #define FONTSET_START_ADDRESS 0x00
-#define START_ADDRESS 0x200
+#define START_ADDRESS		  0x200
 
-#define GET_X(opcode) ((uint8_t) ((opcode >> 8) & 0x000F))
-#define GET_Y(opcode) ((uint8_t) ((opcode >> 4) & 0x000F))
-#define GET_N(opcode) ((uint8_t) (opcode & 0x000F))
-#define GET_KK(opcode) ((uint8_t) (opcode & 0x00FF))
+#define GET_X(opcode)	((uint8_t) ((opcode >> 8) & 0x000F))
+#define GET_Y(opcode)	((uint8_t) ((opcode >> 4) & 0x000F))
+#define GET_N(opcode)	((uint8_t) (opcode & 0x000F))
+#define GET_KK(opcode)	((uint8_t) (opcode & 0x00FF))
 #define GET_NNN(opcode) ((uint16_t) (opcode & 0x0FFF))
 
 typedef void (*op_function)(void);
@@ -24,11 +24,11 @@ static void ILLEGAL_OPCODE(void) {
 }
 #pragma GCC diagnostic pop
 
-op_function instr_lookup[0xF + 1] = { [0 ... 0xF] = ILLEGAL_OPCODE };
-op_function zero_prefixed_lookup[0xE + 1] = { [0 ... 0xE] = ILLEGAL_OPCODE };
-op_function eight_prefixed_lookup[0xE + 1] = { [0 ... 0xE] = ILLEGAL_OPCODE };
-op_function e_prefixed_lookup[0xE + 1] = { [0 ... 0xE] = ILLEGAL_OPCODE };
-op_function f_prefixed_lookup[0x65 + 1] = { [0 ... 0x65] = ILLEGAL_OPCODE };
+op_function instr_lookup[0xF + 1]		   = {[0 ... 0xF] = ILLEGAL_OPCODE};
+op_function zero_prefixed_lookup[0xE + 1]  = {[0 ... 0xE] = ILLEGAL_OPCODE};
+op_function eight_prefixed_lookup[0xE + 1] = {[0 ... 0xE] = ILLEGAL_OPCODE};
+op_function e_prefixed_lookup[0xE + 1]	   = {[0 ... 0xE] = ILLEGAL_OPCODE};
+op_function f_prefixed_lookup[0x65 + 1]	   = {[0 ... 0x65] = ILLEGAL_OPCODE};
 
 uint8_t fontset[FONTSET_SIZE] = {
 	0xF0, 0x90, 0x90, 0x90, 0xF0, // 0
@@ -46,64 +46,65 @@ uint8_t fontset[FONTSET_SIZE] = {
 	0xF0, 0x80, 0x80, 0x80, 0xF0, // C
 	0xE0, 0x90, 0x90, 0x90, 0xE0, // D
 	0xF0, 0x80, 0xF0, 0x80, 0xF0, // E
-	0xF0, 0x80, 0xF0, 0x80, 0x80  // F
+	0xF0, 0x80, 0xF0, 0x80, 0x80, // F
 };
 
 machine_t m = {
-	{ [0 ... (4096-1)] = 0 }, 
-	{ [0 ... (REGISTER_COUNT-1)] = 0 }, 
-	{ [0 ... (STACK_LEVELS-1)] = 0 }, 
-	{ [0 ... (SCREEN_DIMENSIONS-1)] = 0 }, 
-	{ [0 ... (KEY_SIZE-1)] = 0 }, 
-	0, 
+	{[0 ...(4096 - 1)] = 0},
+	{[0 ...(REGISTER_COUNT - 1)] = 0},
+	{[0 ...(STACK_LEVELS - 1)] = 0},
+	{[0 ...(SCREEN_DIMENSIONS - 1)] = 0},
+	{[0 ...(KEY_SIZE - 1)] = 0},
 	0,
 	0,
 	0,
 	0,
 	0,
 	0,
-	0
+	0,
+	0,
 };
 
-void rom_load(const char *filename) {
-    FILE *f;
+void rom_load(char const *filename) {
+	FILE *f;
 	long romSize;
 
 	// Open ROM
-    LOG_INFO("Loading ROM %s", filename);
-    f = fopen(filename, "r");
+	LOG_INFO("Loading ROM %s", filename);
+	f = fopen(filename, "r");
 	if (f == NULL) {
-        LOG_FATAL("%s", strerror(errno));
-        return;
+		LOG_FATAL("%s", strerror(errno));
+		return;
 	}
 
 	// Get the number of bytes
 	fseek(f, 0L, SEEK_END);
 	romSize = ftell(f);
 
-    LOG_DEBUG("Size of ROM: %ld", romSize);
+	LOG_DEBUG("Size of ROM: %ld", romSize);
 
-    if (romSize < 0) {
-        LOG_FATAL("%s", strerror(errno));
-        fclose(f);
-        return;
-    } else if (((unsigned long) romSize) >= UINT16_MAX) {
-        LOG_FATAL("Size of rom %s (%ld) is larger than maximal allowed size %d", filename, romSize, UINT16_MAX);
-        fclose(f);
-        return;
-    }
+	if (romSize < 0) {
+		LOG_FATAL("%s", strerror(errno));
+		fclose(f);
+		return;
+	} else if (((unsigned long) romSize) >= UINT16_MAX) {
+		LOG_FATAL("Size of rom %s (%ld) is larger than maximal allowed size %d", filename, romSize,
+				  UINT16_MAX);
+		fclose(f);
+		return;
+	}
 
 	// reset pointer to beginning of file
 	fseek(f, 0L, SEEK_SET);
 
 	size_t bytesRead = fread(&m.memory[START_ADDRESS], sizeof(uint8_t), (size_t) romSize, f);
-    if (bytesRead != (size_t) romSize) {
-        LOG_FATAL("An error occurred while reading bytes from rom");
-        fclose(f);
-        return;
-    }
+	if (bytesRead != (size_t) romSize) {
+		LOG_FATAL("An error occurred while reading bytes from rom");
+		fclose(f);
+		return;
+	}
 
-    LOG_DEBUG("Successfully read %ld B of ROM", romSize);
+	LOG_DEBUG("Successfully read %ld B of ROM", romSize);
 	fclose(f);
 }
 
@@ -128,8 +129,8 @@ void machine_init(void) {
 
 	m.PC = START_ADDRESS;
 	srand((unsigned int) time(NULL));
-	
-    memcpy(&m.memory[FONTSET_START_ADDRESS], fontset, FONTSET_SIZE);
+
+	memcpy(&m.memory[FONTSET_START_ADDRESS], fontset, FONTSET_SIZE);
 
 	// Set up lookup table
 	instr_lookup[0x0] = ZERO_PREFIXED;
@@ -182,7 +183,7 @@ void cpu_step(void) {
 
 	m.PC += 2;
 
-	// Get and Execute Instruction 
+	// Get and Execute Instruction
 	(*(instr_lookup[(m.opcode & 0xF000) >> 12]))();
 }
 
@@ -210,7 +211,7 @@ void OPC_2nnn(void) {
 }
 
 void OPC_3xkk(void) {
-	uint8_t Vx = GET_X(m.opcode);
+	uint8_t Vx	 = GET_X(m.opcode);
 	uint8_t byte = GET_KK(m.opcode);
 
 	if (m.registers[Vx] == byte) {
@@ -219,7 +220,7 @@ void OPC_3xkk(void) {
 }
 
 void OPC_4xkk(void) {
-	uint8_t Vx = GET_X(m.opcode);
+	uint8_t Vx	 = GET_X(m.opcode);
 	uint8_t byte = GET_KK(m.opcode);
 
 	if (m.registers[Vx] != byte) {
@@ -237,14 +238,14 @@ void OPC_5xy0(void) {
 }
 
 void OPC_6xkk(void) {
-	uint8_t Vx = GET_X(m.opcode);
+	uint8_t Vx	 = GET_X(m.opcode);
 	uint8_t byte = GET_KK(m.opcode);
 
 	m.registers[Vx] = byte;
 }
 
 void OPC_7xkk(void) {
-	uint8_t Vx = GET_X(m.opcode);
+	uint8_t Vx	 = GET_X(m.opcode);
 	uint8_t byte = GET_KK(m.opcode);
 
 	m.registers[Vx] += byte;
@@ -343,22 +344,22 @@ void OPC_Annn(void) {
 
 void OPC_Bnnn(void) {
 	uint16_t reg_addr = GET_NNN(m.opcode);
-	uint8_t offset = m.registers[0];
-	
+	uint8_t offset	  = m.registers[0];
+
 	m.PC = reg_addr + offset;
 }
 
 void OPC_Cxkk(void) {
-	uint8_t Vx = GET_X(m.opcode);
-	uint8_t byte = GET_KK(m.opcode);
+	uint8_t Vx	   = GET_X(m.opcode);
+	uint8_t byte   = GET_KK(m.opcode);
 	uint8_t random = (uint8_t) (rand() & byte);
-	
+
 	m.registers[Vx] = random & byte;
 }
 
 void OPC_Dxyn(void) {
-	uint_fast8_t Vx = (m.opcode & 0x0F00u) >> 8u;
-	uint_fast8_t Vy = (m.opcode & 0x00F0u) >> 4u;
+	uint_fast8_t Vx		= (m.opcode & 0x0F00u) >> 8u;
+	uint_fast8_t Vy		= (m.opcode & 0x00F0u) >> 4u;
 	uint_fast8_t height = m.opcode & 0x000Fu;
 
 	// Wrap if going beyond screen boundaries
@@ -372,11 +373,11 @@ void OPC_Dxyn(void) {
 
 		for (uint_fast8_t col = 0; col < 8; ++col) {
 			uint_fast8_t bit = spritePixel & (0b10000000 >> col);
-			uint32_t* pixel = &m.video[(vyValue + row) * VIDEO_WIDTH + (vxValue + col)];
+			uint32_t *pixel	 = &m.video[(vyValue + row) * VIDEO_WIDTH + (vxValue + col)];
 
 			// Sprite pixel is set
 			if (bit) {
-				if (*pixel == 0xFFFFFFFF) {	// pixel on screen => set carry/collision bit
+				if (*pixel == 0xFFFFFFFF) { // pixel on screen => set carry/collision bit
 					m.registers[0xF] = 1;
 				}
 
@@ -387,7 +388,7 @@ void OPC_Dxyn(void) {
 }
 
 void OPC_Ex9E(void) {
-	uint8_t Vx = GET_X(m.opcode);
+	uint8_t Vx	= GET_X(m.opcode);
 	uint8_t key = m.registers[Vx];
 
 	if (m.keys[key]) {
@@ -396,7 +397,7 @@ void OPC_Ex9E(void) {
 }
 
 void OPC_ExA1(void) {
-	uint8_t Vx = GET_X(m.opcode);
+	uint8_t Vx	= GET_X(m.opcode);
 	uint8_t key = m.registers[Vx];
 
 	if (!m.keys[key]) {
@@ -405,7 +406,7 @@ void OPC_ExA1(void) {
 }
 
 void OPC_Fx07(void) {
-	uint8_t Vx = GET_X(m.opcode);
+	uint8_t Vx		= GET_X(m.opcode);
 	m.registers[Vx] = m.delay_timer;
 }
 
@@ -441,14 +442,14 @@ void OPC_Fx1E(void) {
 }
 
 void OPC_Fx29(void) {
-	uint8_t Vx = GET_X(m.opcode);
+	uint8_t Vx	  = GET_X(m.opcode);
 	uint8_t value = m.registers[Vx];
 
 	m.index = FONTSET_START_ADDRESS + (5 * value); // 5 = font char width
 }
 
 void OPC_Fx33(void) {
-	uint8_t Vx = GET_X(m.opcode);
+	uint8_t Vx	  = GET_X(m.opcode);
 	uint8_t value = m.registers[Vx];
 
 	// 1s
@@ -466,11 +467,11 @@ void OPC_Fx33(void) {
 void OPC_Fx55(void) {
 	uint8_t Vx = GET_X(m.opcode);
 
-    memcpy(&m.memory[m.index], m.registers, Vx + 1);
+	memcpy(&m.memory[m.index], m.registers, Vx + 1);
 }
 
 void OPC_Fx65(void) {
 	uint8_t Vx = GET_X(m.opcode);
 
-    memcpy(m.registers, &m.memory[m.index], Vx + 1);
+	memcpy(m.registers, &m.memory[m.index], Vx + 1);
 }

--- a/src/cpu.h
+++ b/src/cpu.h
@@ -7,15 +7,15 @@
 #include <stdio.h>
 #include <time.h>
 
-#define MEMORY_SIZE 4096
-#define REGISTER_COUNT 16
-#define STACK_LEVELS 16
-#define KEY_SIZE 16
-#define VIDEO_HEIGHT 32
-#define VIDEO_WIDTH 64
+#define MEMORY_SIZE		  4096
+#define REGISTER_COUNT	  16
+#define STACK_LEVELS	  16
+#define KEY_SIZE		  16
+#define VIDEO_HEIGHT	  32
+#define VIDEO_WIDTH		  64
 #define SCREEN_DIMENSIONS (VIDEO_WIDTH * VIDEO_HEIGHT)
 
-void rom_load(const char *filename);
+void rom_load(char const *filename);
 void machine_init(void);
 void cpu_step(void);
 
@@ -83,7 +83,7 @@ void OPC_8xy4(void);
 // SUB Vx, Vy: Set Vx := Vx - Vy, set VF := NOT borrow.
 void OPC_8xy5(void);
 
-// SHR Vx: Set Vx = Vx SHR 1. 
+// SHR Vx: Set Vx = Vx SHR 1.
 void OPC_8xy6(void);
 
 // SUBN Vx, Vy: Set Vx := Vy - Vx, set VF = NOT borrow.
@@ -129,7 +129,8 @@ void OPC_Fx18(void);
 // Fx1E - ADD I, Vx: Set I = I + Vx. The values of I and Vx are added, and the results are stored in I.
 void OPC_Fx1E(void);
 
-// Fx29 - LD F, Vx: Set I = location of sprite for digit Vx. The value of I is set to the location for the hexadecimal sprite corresponding to the value of Vx.
+// Fx29 - LD F, Vx: Set I = location of sprite for digit Vx. The value of I is set to the location for the
+// hexadecimal sprite corresponding to the value of Vx.
 void OPC_Fx29(void);
 
 // Fx33 - LD B, Vx: Store BCD representation of Vx in memory locations I, I+1, and I+2.

--- a/src/cretro.c
+++ b/src/cretro.c
@@ -11,20 +11,20 @@
 #include "cli.h"
 #include "logging.h"
 
-int main(int argc, char** argv) {
-    arg_conf* conf = cli_config_default();
+int main(int argc, char **argv) {
+	arg_conf *conf = cli_config_default();
 
 	if (cli_config_handle(conf, argc, argv)) {
-        cli_config_destroy(conf);
-        return EXIT_FAILURE;
-    }
+		cli_config_destroy(conf);
+		return EXIT_FAILURE;
+	}
 
 	machine_init();
 
 	rom_load(conf->rom_path);
 	LOG_INFO("Successfully initialized ROM");
 
-    lcd_init();
+	lcd_init();
 	LOG_INFO("Successfully initialized LCD");
 
 	int videoPitch = sizeof(m.video[0]) * VIDEO_WIDTH;
@@ -37,13 +37,13 @@ int main(int argc, char** argv) {
 	pthread_create(&tid, NULL, &timer_update_callback, NULL);
 
 	bool running = true;
-    while (running) {
+	while (running) {
 		running = lcd_process_input();
 
 		handle_sound();
 
 		struct timeval clock_now;
-	    gettimeofday(&clock_now, NULL);
+		gettimeofday(&clock_now, NULL);
 		long dt = timediff_us(&clock_now, &cpu_clock_prev);
 		if (dt > conf->us_delay) {
 			cpu_step();
@@ -53,7 +53,7 @@ int main(int argc, char** argv) {
 	}
 
 	SDL_Quit();
-    cli_config_destroy(conf);
+	cli_config_destroy(conf);
 
-    return EXIT_SUCCESS;
+	return EXIT_SUCCESS;
 }

--- a/src/cretro.c
+++ b/src/cretro.c
@@ -27,7 +27,7 @@ int main(int argc, char **argv) {
 	lcd_init();
 	LOG_INFO("Successfully initialized LCD");
 
-	int videoPitch = sizeof(m.video[0]) * VIDEO_WIDTH;
+	int video_pitch = sizeof(m.video[0]) * VIDEO_WIDTH;
 
 	struct timeval cpu_clock_prev;
 	gettimeofday(&cpu_clock_prev, NULL);
@@ -47,7 +47,7 @@ int main(int argc, char **argv) {
 		long dt = timediff_us(&clock_now, &cpu_clock_prev);
 		if (dt > conf->us_delay) {
 			cpu_step();
-			lcd_step(m.video, videoPitch);
+			lcd_step(m.video, video_pitch);
 			cpu_clock_prev = clock_now;
 		}
 	}

--- a/src/lcd.c
+++ b/src/lcd.c
@@ -10,19 +10,14 @@ static SDL_Texture *texture;
 void lcd_init(void) {
 	SDL_Init(SDL_INIT_EVERYTHING);
 
-	window = SDL_CreateWindow(
-		"cretro - Chip 8 Emulator",
-		SDL_WINDOWPOS_UNDEFINED,
-		SDL_WINDOWPOS_UNDEFINED,
-		640, 320,
-		SDL_WINDOW_INPUT_FOCUS
-	);
+	window = SDL_CreateWindow("cretro - Chip 8 Emulator", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
+							  640, 320, SDL_WINDOW_INPUT_FOCUS);
 
 	renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED);
-	texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_STREAMING, 64, 32);
+	texture	 = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_STREAMING, 64, 32);
 }
 
-static void process_key(const SDL_Event *e, bool value) {
+static void process_key(SDL_Event const *e, bool value) {
 	switch (e->key.keysym.sym) {
 		case SDLK_x:
 			m.keys[0] = value;
@@ -84,29 +79,29 @@ bool lcd_process_input(void) {
 
 	while (SDL_PollEvent(&e)) {
 		switch (e.type) {
-		case SDL_QUIT:
-			running = SDL_FALSE;
-			break;
-		case SDL_KEYDOWN:
-			if (e.key.keysym.sym == SDLK_ESCAPE) {
+			case SDL_QUIT:
 				running = SDL_FALSE;
 				break;
-			}
-			process_key(&e, 1);
-			break;
-		case SDL_KEYUP:
-			process_key(&e, 0);
-			break;
-        default:
-            // Ignore unknown key events
-            break;
+			case SDL_KEYDOWN:
+				if (e.key.keysym.sym == SDLK_ESCAPE) {
+					running = SDL_FALSE;
+					break;
+				}
+				process_key(&e, 1);
+				break;
+			case SDL_KEYUP:
+				process_key(&e, 0);
+				break;
+			default:
+				// Ignore unknown key events
+				break;
 		}
 	}
 
 	return running;
 }
 
-void lcd_step(const void *buffer, int pitch) {
+void lcd_step(void const *buffer, int pitch) {
 	SDL_UpdateTexture(texture, NULL, buffer, pitch);
 	SDL_SetTextureColorMod(texture, 69, 170, 242);
 	SDL_RenderClear(renderer);

--- a/src/lcd.h
+++ b/src/lcd.h
@@ -8,6 +8,6 @@
 
 void lcd_init(void);
 bool lcd_process_input(void);
-void lcd_step(void const* buffer, int pitch);
+void lcd_step(void const *buffer, int pitch);
 
 #endif

--- a/src/logging.c
+++ b/src/logging.c
@@ -3,7 +3,6 @@
 
 #include "logging.h"
 
-
 /******************************************************
  *** LOCAL DEFINES                                  ***
  ******************************************************/
@@ -22,34 +21,36 @@ static log_level min_dbg_lvl = FATAL;
  *** EXPOSED METHODS                                ***
  ******************************************************/
 
-void log_set_lvl(const arg_conf* conf) {
-    min_dbg_lvl = (log_level) conf->debug;
+void log_set_lvl(arg_conf const *conf) {
+	min_dbg_lvl = (log_level) conf->debug;
 
-    // minimum debug level cannot be higher than fatal
-    if (min_dbg_lvl > FATAL)
-        min_dbg_lvl = FATAL;
+	// minimum debug level cannot be higher than fatal
+	if (min_dbg_lvl > FATAL)
+		min_dbg_lvl = FATAL;
 
-    // minimum debug level cannot be lower than debug
-    if (min_dbg_lvl < DEBUG)
-        min_dbg_lvl = DEBUG;
+	// minimum debug level cannot be lower than debug
+	if (min_dbg_lvl < DEBUG)
+		min_dbg_lvl = DEBUG;
 
-    LOG_INFO("Log level initialized to %d.", min_dbg_lvl);
+	LOG_INFO("Log level initialized to %d.", min_dbg_lvl);
 }
 
-__attribute__((format(printf, 4, 5))) void log_str(log_level dbg_lvl, const char* dbg_lvl_str, FILE* stream, const char *msg, ...) {
-    if (dbg_lvl < min_dbg_lvl) return;
+__attribute__((format(printf, 4, 5))) void log_str(log_level dbg_lvl, char const *dbg_lvl_str, FILE *stream,
+												   char const *msg, ...) {
+	if (dbg_lvl < min_dbg_lvl)
+		return;
 
-    va_list args;
-    time_t rawtime;
-    struct tm * timeinfo;
+	va_list args;
+	time_t rawtime;
+	struct tm *timeinfo;
 
-    va_start(args, msg);
-    time(&rawtime);
-    timeinfo = localtime(&rawtime);
-    char* time_str = asctime(timeinfo);
-    time_str[24] = '\0'; // terminate str early to eliminate newline (i hate this)
+	va_start(args, msg);
+	time(&rawtime);
+	timeinfo	   = localtime(&rawtime);
+	char *time_str = asctime(timeinfo);
+	time_str[24]   = '\0'; // terminate str early to eliminate newline (i hate this)
 
-    fprintf(stream, "%10s – %s – ", dbg_lvl_str, time_str);
-    vfprintf(stream, msg, args);
-    fprintf(stream, "\n");
+	fprintf(stream, "%10s – %s – ", dbg_lvl_str, time_str);
+	vfprintf(stream, msg, args);
+	fprintf(stream, "\n");
 }

--- a/src/logging.h
+++ b/src/logging.h
@@ -1,5 +1,5 @@
-#ifndef _CH8_SRC_DEBUG_H_
-#define _CH8_SRC_DEBUG_H_
+#ifndef LOGGING_H
+#define LOGGING_H
 
 #include <stdio.h>
 
@@ -17,4 +17,4 @@ void log_set_lvl(arg_conf const *conf);
 #define LOG_ERROR(msg, ...)	  log_str(ERROR, "ERROR", stderr, msg, ##__VA_ARGS__)
 #define LOG_FATAL(msg, ...)	  log_str(FATAL, "FATAL", stderr, msg, ##__VA_ARGS__)
 
-#endif /* _CH8_SRC_DEBUG_H_ */
+#endif /* LOGGING_H */

--- a/src/logging.h
+++ b/src/logging.h
@@ -5,7 +5,13 @@
 
 #include "cli.h"
 
-typedef enum log_level { DEBUG, INFO, WARNING, ERROR, FATAL } log_level;
+typedef enum log_level {
+	DEBUG,
+	INFO,
+	WARNING,
+	ERROR,
+	FATAL
+} log_level;
 
 void log_str(log_level dbg_lvl, char const *dbg_lvl_str, FILE *stream, char const *msg, ...);
 

--- a/src/logging.h
+++ b/src/logging.h
@@ -5,22 +5,16 @@
 
 #include "cli.h"
 
-typedef enum log_level {
-    DEBUG,
-    INFO,
-    WARNING,
-    ERROR,
-    FATAL
-} log_level;
+typedef enum log_level { DEBUG, INFO, WARNING, ERROR, FATAL } log_level;
 
-void log_str(log_level dbg_lvl, const char* dbg_lvl_str, FILE* stream, const char* msg, ...);
+void log_str(log_level dbg_lvl, char const *dbg_lvl_str, FILE *stream, char const *msg, ...);
 
-void log_set_lvl(const arg_conf* conf);
+void log_set_lvl(arg_conf const *conf);
 
-#define LOG_DEBUG(msg, ...)     log_str(DEBUG, "DEBUG", stdout, msg, ##__VA_ARGS__)
-#define LOG_INFO(msg, ...)      log_str(INFO, "INFO", stdout, msg, ##__VA_ARGS__)
-#define LOG_WARNING(msg, ...)   log_str(WARNING, "WARNING", stdout, msg, ##__VA_ARGS__)
-#define LOG_ERROR(msg, ...)     log_str(ERROR, "ERROR", stderr, msg, ##__VA_ARGS__)
-#define LOG_FATAL(msg, ...)     log_str(FATAL, "FATAL", stderr, msg, ##__VA_ARGS__)
+#define LOG_DEBUG(msg, ...)	  log_str(DEBUG, "DEBUG", stdout, msg, ##__VA_ARGS__)
+#define LOG_INFO(msg, ...)	  log_str(INFO, "INFO", stdout, msg, ##__VA_ARGS__)
+#define LOG_WARNING(msg, ...) log_str(WARNING, "WARNING", stdout, msg, ##__VA_ARGS__)
+#define LOG_ERROR(msg, ...)	  log_str(ERROR, "ERROR", stderr, msg, ##__VA_ARGS__)
+#define LOG_FATAL(msg, ...)	  log_str(FATAL, "FATAL", stderr, msg, ##__VA_ARGS__)
 
 #endif /* _CH8_SRC_DEBUG_H_ */

--- a/src/sound.c
+++ b/src/sound.c
@@ -1,54 +1,54 @@
 #include "sound.h"
 #include "logging.h"
 
-#define PI 3.14159265358979323846
+#define PI		  3.14159265358979323846
 #define AMPLITUDE 127
 #define FREQUENCY 44100
 
 static void audio_callback(void *user_data, uint8_t *stream, int len) {
-    if (len < 0) {
-        LOG_FATAL("len cannot be negative");
-    } else if (sizeof(int) > sizeof(size_t) && len > SIZE_MAX) {
-        LOG_FATAL("len %d is larger than allowed %lu", len, SIZE_MAX);
-    }
+	if (len < 0) {
+		LOG_FATAL("len cannot be negative");
+	} else if (sizeof(int) > sizeof(size_t) && len > SIZE_MAX) {
+		LOG_FATAL("len %d is larger than allowed %lu", len, SIZE_MAX);
+	}
 
-    SDL_memset(stream, 0, (size_t) len);
-    (void) user_data; // tell the compiler that user_data is not used
+	SDL_memset(stream, 0, (size_t) len);
+	(void) user_data; // tell the compiler that user_data is not used
 
-    for (int i = 0; i < len; ++i) {
-        stream[i] = (uint8_t) (AMPLITUDE * sin(i * PI * 2 * 604.1 / FREQUENCY));
-    }
+	for (int i = 0; i < len; ++i) {
+		stream[i] = (uint8_t) (AMPLITUDE * sin(i * PI * 2 * 604.1 / FREQUENCY));
+	}
 }
 
 static void sound_play(void) {
-    SDL_PauseAudio(0);
+	SDL_PauseAudio(0);
 }
 
 static void sound_stop(void) {
-    SDL_PauseAudio(1);
+	SDL_PauseAudio(1);
 }
 
 int sound_init() {
-    SDL_AudioSpec want;
-    want.freq = FREQUENCY;
-    want.format = AUDIO_S8;
-    want.channels = 1;
-    want.samples = 128; // buffer-size
-    want.callback = audio_callback; // callback to refill buffer
+	SDL_AudioSpec want;
+	want.freq	  = FREQUENCY;
+	want.format	  = AUDIO_S8;
+	want.channels = 1;
+	want.samples  = 128;			// buffer-size
+	want.callback = audio_callback; // callback to refill buffer
 
-    SDL_AudioSpec have;
-    if (SDL_OpenAudio(&want, &have)) {
-        SDL_LogError(SDL_LOG_CATEGORY_AUDIO, "Failed to open audio: %s", SDL_GetError());
-        return 1;
-    }
+	SDL_AudioSpec have;
+	if (SDL_OpenAudio(&want, &have)) {
+		SDL_LogError(SDL_LOG_CATEGORY_AUDIO, "Failed to open audio: %s", SDL_GetError());
+		return 1;
+	}
 
-    return 0;
+	return 0;
 }
 
 void handle_sound() {
-    if (m.should_beep) {
-        sound_play();
-    } else {
-        sound_stop();
-    }
+	if (m.should_beep) {
+		sound_play();
+	} else {
+		sound_stop();
+	}
 }

--- a/src/timer.c
+++ b/src/timer.c
@@ -3,47 +3,47 @@
 #define TIMER_DELAY (1000 / 60)
 
 long timediff_us(const struct timeval *end, const struct timeval *start) {
-    long diff = (end->tv_sec - start->tv_sec) * 1000000L + (end->tv_usec - start->tv_usec);
-    return diff;
+	long diff = (end->tv_sec - start->tv_sec) * 1000000L + (end->tv_usec - start->tv_usec);
+	return diff;
 }
-  
+
 int msleep(long msec) {
-    struct timespec ts;
-    int res;
+	struct timespec ts;
+	int res;
 
-    if (msec < 0) {
-        errno = EINVAL;
-        return -1;
-    }
+	if (msec < 0) {
+		errno = EINVAL;
+		return -1;
+	}
 
-    ts.tv_sec = msec / 1000;
-    ts.tv_nsec = (msec % 1000) * 1000000;
+	ts.tv_sec  = msec / 1000;
+	ts.tv_nsec = (msec % 1000) * 1000000;
 
-    do {
-        res = nanosleep(&ts, &ts);
-    } while (res && errno == EINTR);
+	do {
+		res = nanosleep(&ts, &ts);
+	} while (res && errno == EINTR);
 
-    return res;
+	return res;
 }
 
 static void update_timers(void) {
-    // Decrease timers if necessary
-    if (m.delay_timer > 0) {
-        --m.delay_timer;
-    }
+	// Decrease timers if necessary
+	if (m.delay_timer > 0) {
+		--m.delay_timer;
+	}
 
-    if (m.sound_timer > 0) {
-        m.should_beep = 1;
-        --m.sound_timer;
-    } else {
-        m.should_beep = 0;
-    }
+	if (m.sound_timer > 0) {
+		m.should_beep = 1;
+		--m.sound_timer;
+	} else {
+		m.should_beep = 0;
+	}
 }
 
-void *timer_update_callback(void* unused) {
+void *timer_update_callback(void *unused) {
 	(void) unused;
-    while (1) {
-        msleep(TIMER_DELAY);
-        update_timers();
-    }
+	while (1) {
+		msleep(TIMER_DELAY);
+		update_timers();
+	}
 }

--- a/src/timer.h
+++ b/src/timer.h
@@ -11,7 +11,7 @@
 
 int nanosleep(const struct timespec *req, struct timespec *rem);
 int msleep(long msec);
-_Noreturn void *timer_update_callback(void* unused);
+_Noreturn void *timer_update_callback(void *unused);
 __attribute__((pure)) long timediff_us(const struct timeval *end, const struct timeval *start);
 
 #endif


### PR DESCRIPTION
This is an initial proposal for a .clang-format and .clang-tidy setup. 739e3e53ef684e0c6d4fb22c47325af56f37dd88 and 25eea57dfb550d10202a27876509368780ebba6c respectively show clang-format and clang-tidy changes.

I would suggest not looking at the changes, since github does not display everything correctly. Instead looking at the source directly should be better.

Some major points:
- use 4 spaces
- right align pointer *
- Break after certain line width

This addresses #13.